### PR TITLE
Add typing, minor fixes

### DIFF
--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -32,7 +32,7 @@ except ImportError:
     pass
 
 try:
-    from typing import Optional, Union, Tuple
+    from typing import Optional, Union, Tuple, List
     from audioio import AudioOut
 except ImportError:
     pass
@@ -102,7 +102,7 @@ def _parse_note(note: str, duration: int = 2, octave: int = 6) -> Tuple[str, flo
     return piano_note, note_duration
 
 
-def _get_wave(tune: str, octave: int) -> Tuple[sine.sine_wave, float]:
+def _get_wave(tune: str, octave: int) -> Tuple[List[int], float]:
     """Returns the proper waveform to play the song along with the minimum
     frequency in the song.
     """

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -148,7 +148,7 @@ def _play_to_pin(tune: str, base_tone: Union[pwmio.PWMOut, AudioOut], min_freq: 
 def play(pin, rtttl: str, octave: int = Optional[None], duration: Optional[int] = None, tempo: Optional[int] = None) -> None:
     """Play notes to a digialio pin using ring tone text transfer language (rtttl).
     :param ~digitalio.DigitalInOut pin: the speaker pin
-    :param rtttl: string containing rtttl
+    :param str rtttl: string containing rtttl
     :param int octave: represents octave number (default 6 starts at middle c)
     :param int duration: length of notes (default 4 quarter note)
     :param int tempo: how fast (default 63 beats per minute)

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -95,7 +95,7 @@ def _parse_note(note: str, duration: int = 2, octave: int = 6) -> Tuple[str, flo
         note_duration *= 1.5
     if "#" in note:
         piano_note += "#"
-    note_octave = octave
+    note_octave = str(octave)
     if note[-1].isdigit():
         note_octave = note[-1]
     piano_note = note_octave + piano_note

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -31,6 +31,12 @@ try:
 except ImportError:
     pass
 
+try:
+    from typing import Optional, Union, Tuple
+    from audioio import AudioOut
+except ImportError:
+    pass
+
 PIANO = {
     "4c": 261.626,
     "4c#": 277.183,
@@ -73,7 +79,7 @@ PIANO = {
 }
 
 
-def _parse_note(note, duration=2, octave="6"):
+def _parse_note(note: str, duration: int = 2, octave: int = 6) -> Tuple[str, float]:
     note = note.strip()
     piano_note = None
     note_duration = duration
@@ -96,7 +102,7 @@ def _parse_note(note, duration=2, octave="6"):
     return piano_note, note_duration
 
 
-def _get_wave(tune, octave):
+def _get_wave(tune: str, octave: int) -> Tuple[sine.sine_wave, float]:
     """Returns the proper waveform to play the song along with the minimum
     frequency in the song.
     """
@@ -110,7 +116,7 @@ def _get_wave(tune, octave):
 
 
 # pylint: disable-msg=too-many-arguments
-def _play_to_pin(tune, base_tone, min_freq, duration, octave, tempo):
+def _play_to_pin(tune: str, base_tone: Union[pwmio.PWMOut, AudioOut], min_freq: float, duration: int, octave: int, tempo: int) -> None:
     """Using the prepared input send the notes to the pin"""
     pwm = isinstance(base_tone, pwmio.PWMOut)
     for note in tune.split(","):
@@ -139,7 +145,7 @@ def _play_to_pin(tune, base_tone, min_freq, duration, octave, tempo):
 
 
 # pylint: disable-msg=too-many-arguments
-def play(pin, rtttl, octave=None, duration=None, tempo=None):
+def play(pin, rtttl: str, octave: int = Optional[None], duration: Optional[int] = None, tempo: Optional[int] = None) -> None:
     """Play notes to a digialio pin using ring tone text transfer language (rtttl).
     :param ~digitalio.DigitalInOut pin: the speaker pin
     :param rtttl: string containing rtttl

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -116,7 +116,14 @@ def _get_wave(tune: str, octave: int) -> Tuple[sine.sine_wave, float]:
 
 
 # pylint: disable-msg=too-many-arguments
-def _play_to_pin(tune: str, base_tone: Union[pwmio.PWMOut, AudioOut], min_freq: float, duration: int, octave: int, tempo: int) -> None:
+def _play_to_pin(
+    tune: str,
+    base_tone: Union[pwmio.PWMOut, AudioOut],
+    min_freq: float,
+    duration: int,
+    octave: int,
+    tempo: int,
+) -> None:
     """Using the prepared input send the notes to the pin"""
     pwm = isinstance(base_tone, pwmio.PWMOut)
     for note in tune.split(","):
@@ -145,7 +152,13 @@ def _play_to_pin(tune: str, base_tone: Union[pwmio.PWMOut, AudioOut], min_freq: 
 
 
 # pylint: disable-msg=too-many-arguments
-def play(pin, rtttl: str, octave: int = Optional[None], duration: Optional[int] = None, tempo: Optional[int] = None) -> None:
+def play(
+    pin,
+    rtttl: str,
+    octave: int = Optional[None],
+    duration: Optional[int] = None,
+    tempo: Optional[int] = None,
+) -> None:
     """Play notes to a digialio pin using ring tone text transfer language (rtttl).
     :param ~digitalio.DigitalInOut pin: the speaker pin
     :param str rtttl: string containing rtttl

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
-autodoc_mock_imports = ["pulseio"]
+autodoc_mock_imports = ["pulseio", "pwmio"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
-autodoc_mock_imports = ["pulseio", "pwmio"]
+autodoc_mock_imports = ["pulseio", "pwmio", "audioio"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
-autodoc_mock_imports = ["pulseio", "adafruit_waveform"]
+autodoc_mock_imports = ["pulseio"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
-autodoc_mock_imports = ["pulseio"]
+autodoc_mock_imports = ["pulseio", "adafruit_waveform"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,4 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-Adafruit-Blinka
 sphinx>=4.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+Adafruit-Blinka
 sphinx>=4.0.0


### PR DESCRIPTION
A few things:

- Added type hints
- `parse_note()` now casts its argument to `str` which I believe was the intention, and is my understanding of the correct implementation reading the code.  Would definitely appreciate a second set of eyes on that.
- Added a small addition to one of the docstrings to add type to the Sphinx param
- Had to add `pwmio` and `audioio` to mock imports because Sphinx failed building otherwise