### PR TITLE
fix typing for play() function args

### DIFF
--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -155,7 +155,7 @@ def _play_to_pin(
 def play(
     pin,
     rtttl: str,
-    octave: int = Optional[None],
+    octave: Optional[int] = None,
     duration: Optional[int] = None,
     tempo: Optional[int] = None,
 ) -> None:


### PR DESCRIPTION
resolves: #26 

The syntax on the typing for one of the arguments was a little different than the others. This PR changes it to match the others and that appears to get everything back to working order.

Tested successfully on Wio Terminal:
```
Adafruit CircuitPython 7.1.0-beta.1 on 2021-11-30; Seeeduino Wio Terminal with samd51p19
Board ID:seeeduino_wio_terminal
```