### PR TITLE
Print error about missing waveform library

### DIFF
--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -22,8 +22,10 @@ AUDIOIO_AVAILABLE = False
 WAVEFORM_AVAILABLE = False
 try:
     import audioio
+
     AUDIOIO_AVAILABLE = True
     from adafruit_waveform import sine
+
     WAVEFORM_AVAILABLE = True
     try:
         import audiocore

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -33,7 +33,7 @@ try:
         audiocore = audioio
 except ImportError as e:
     if not HAVE_WAVEFORM_LIBRARY:
-        raise(e)
+        raise e
 
 try:
     from typing import Optional, Union, Tuple, List

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -23,6 +23,7 @@ HAVE_WAVEFORM_LIBRARY = False
 try:
     import audioio
     from adafruit_waveform import sine
+
     HAVE_WAVEFORM_LIBRARY = True
 
     AUDIOIO_AVAILABLE = True
@@ -33,7 +34,6 @@ try:
 except ImportError as e:
     if not HAVE_WAVEFORM_LIBRARY:
         print("Have audioio module but missing adafruit_waveform library")
-
 
 try:
     from typing import Optional, Union, Tuple, List

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -19,20 +19,18 @@ import time
 import pwmio
 
 AUDIOIO_AVAILABLE = False
-HAVE_WAVEFORM_LIBRARY = False
+WAVEFORM_AVAILABLE = False
 try:
     import audioio
-    from adafruit_waveform import sine
-
-    HAVE_WAVEFORM_LIBRARY = True
-
     AUDIOIO_AVAILABLE = True
+    from adafruit_waveform import sine
+    WAVEFORM_AVAILABLE = True
     try:
         import audiocore
     except ImportError:
         audiocore = audioio
 except ImportError as e:
-    if not HAVE_WAVEFORM_LIBRARY:
+    if not WAVEFORM_AVAILABLE:
         raise e
 
 try:

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -33,7 +33,7 @@ try:
         audiocore = audioio
 except ImportError as e:
     if not HAVE_WAVEFORM_LIBRARY:
-        print("Have audioio module but missing adafruit_waveform library")
+        raise(e)
 
 try:
     from typing import Optional, Union, Tuple, List

--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -19,17 +19,21 @@ import time
 import pwmio
 
 AUDIOIO_AVAILABLE = False
+HAVE_WAVEFORM_LIBRARY = False
 try:
     import audioio
     from adafruit_waveform import sine
+    HAVE_WAVEFORM_LIBRARY = True
 
     AUDIOIO_AVAILABLE = True
     try:
         import audiocore
     except ImportError:
         audiocore = audioio
-except ImportError:
-    pass
+except ImportError as e:
+    if not HAVE_WAVEFORM_LIBRARY:
+        print("Have audioio module but missing adafruit_waveform library")
+
 
 try:
     from typing import Optional, Union, Tuple, List

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
-autodoc_mock_imports = ["pulseio", "pwmio", "audioio"]
+autodoc_mock_imports = ["pulseio", "pwmio", "audioio", "adafruit_waveform"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),


### PR DESCRIPTION
This resolves: #28 

The root cause was that audioio did exist but I did not properly load the `adafruit_waveform` library which gets caught by the same except block that is checking for audioio. That caused the library to fall back to pwm which is invalid for the PyPortals pin so raising the exception from that makes sense.

This PR adds a more clear message to let the user know specifically that they do have `audioio` but are missing the `adafruit_waveform` library.