### PR TITLE
Only error if both imports cannot be found, otherwise use pwmio

### DIFF
--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -32,7 +32,7 @@ try:
     except ImportError:
         audiocore = audioio
 except ImportError as e:
-    if not WAVEFORM_AVAILABLE:
+    if AUDIOIO_AVAILABLE and not WAVEFORM_AVAILABLE:
         raise e
 
 try:


### PR DESCRIPTION
Based on using this with my QTPy ESP32-S2, I think the intent is to try and use `audioio` and `adafruit_waveform` if possible, but default to `pwmio` if needed (if not both, in other words, tell the user to add `adafruit_waveform` ONLY if `audioio` is available).  This fixes an issue with the logic currently preventing usage of this library on boards without `audioio`.  Tested with `Adafruit CircuitPython 8.0.0-alpha.1 on 2022-06-09; Adafruit QT Py ESP32S2 with ESP32S2`.

Fixes #31 