### PR TITLE
Fix timing of dotted notes

### DIFF
--- a/adafruit_rtttl.py
+++ b/adafruit_rtttl.py
@@ -96,7 +96,7 @@ def _parse_note(note: str, duration: int = 2, octave: int = 6) -> Tuple[str, flo
     else:
         piano_note = note[0]
     if "." in note:
-        note_duration *= 1.5
+        note_duration /= 1.5
     if "#" in note:
         piano_note += "#"
     note_octave = str(octave)


### PR DESCRIPTION
Dotting a note lengthens it by 1/2. In the code, the `duration` parameter is
actually a divisor of the length of the note (e.g. 1 is a whole note but 4
is a quarter note (1/4 the length)), so dotting should divide the `duration`
by 1.5 instead of multiplying.